### PR TITLE
Paymaster deposit script

### DIFF
--- a/account_abstraction.py
+++ b/account_abstraction.py
@@ -170,7 +170,7 @@ def start_paymaster(config: Config):
            "SIMPLE_ACCOUNT_FACTORY_ADDRESS": simple_account_factory_address,
            "PAYMASTER_ADDRESS": paymaster_address,
            "TIME_VALIDITY": str(config.paymaster_validity),
-           "INITIAL_DEPOSIT": config.paymaster_initial_deposit,
+           "INITIAL_DEPOSIT": str(config.paymaster_initial_deposit),
            "PRIVATE_KEY": config.paymaster_key}
 
     lib.run(

--- a/account_abstraction.py
+++ b/account_abstraction.py
@@ -170,7 +170,14 @@ def start_paymaster(config: Config):
            "SIMPLE_ACCOUNT_FACTORY_ADDRESS": simple_account_factory_address,
            "PAYMASTER_ADDRESS": paymaster_address,
            "TIME_VALIDITY": str(config.paymaster_validity),
+           "INITIAL_DEPOSIT": config.paymaster_initial_deposit,
            "PRIVATE_KEY": config.paymaster_key}
+
+    lib.run(
+        "deposit initial funds for paymaster",
+        command=deps.cmd_with_node("pnpm run deposit"),
+        cwd="paymaster",
+        env=env)
 
     # start paymaster signer service
     log_file_path = f"{config.logs_dir}/paymaster_signer.log"

--- a/config/account_abstraction.py
+++ b/config/account_abstraction.py
@@ -8,6 +8,11 @@ class AccountAbstractionConfig:
     def __init__(self):
         super().__init__()
 
+        self.paymaster_initial_deposit = "3"
+        """
+        Initial deposit amount (in Ether) for the paymaster contract.
+        """
+
         self.paymaster_validity = 300
         """
         Time validity (in seconds) for the sponsored transaction that is signed by paymaster.

--- a/config/account_abstraction.py
+++ b/config/account_abstraction.py
@@ -8,7 +8,7 @@ class AccountAbstractionConfig:
     def __init__(self):
         super().__init__()
 
-        self.paymaster_initial_deposit = "3"
+        self.paymaster_initial_deposit = 3
         """
         Initial deposit amount (in Ether) for the paymaster contract.
         """

--- a/paymaster/package.json
+++ b/paymaster/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "deposit": "npx ts-node script/deposit.ts",
     "start": "tsc && node dist/src/server.js",
     "test": "npx ts-node test/tests.ts"
   },

--- a/paymaster/script/deposit.ts
+++ b/paymaster/script/deposit.ts
@@ -1,0 +1,26 @@
+import { ethers } from 'ethers';
+import dotenv from 'dotenv';
+import { paymasterAbi } from '../src/abis';
+dotenv.config();
+
+async function main() {
+    const depositAmount = process.env.INITIAL_DEPOSIT as string;
+    const provider = new ethers.JsonRpcProvider(process.env.RPC_URL as string);
+    const signer = new ethers.Wallet(process.env.PRIVATE_KEY as string, provider);
+
+    // Paymaster first needs to have funds in Entrypoint contract
+    const paymasterAddress = process.env.PAYMASTER_ADDRESS as string;
+    const paymaster = new ethers.Contract(
+        paymasterAddress,
+        paymasterAbi,
+        signer
+    );
+
+    // Deposit
+    await (await paymaster.deposit({ value: ethers.parseEther(depositAmount)})).wait();
+    await (await paymaster.addStake(3000, { value: ethers.parseEther(depositAmount)})).wait();
+
+    console.log("Deposit funds successful!");
+}
+
+main();

--- a/paymaster/test/tests.ts
+++ b/paymaster/test/tests.ts
@@ -9,15 +9,13 @@ async function main() {
     const provider = new ethers.JsonRpcProvider(process.env.RPC_URL as string);
     const signer = new ethers.Wallet(process.env.PRIVATE_KEY as string, provider);
 
-    // Paymaster first needs to have funds in Entrypoint contract
+    // Initialize paymaster contract
     const paymasterAddress = process.env.PAYMASTER_ADDRESS as string;
     const paymaster = new ethers.Contract(
         paymasterAddress,
         paymasterAbi,
-        signer
+        provider
     );
-    await (await paymaster.deposit({ value: ethers.parseEther('3')})).wait();
-    await (await paymaster.addStake(3000, { value: ethers.parseEther('3')})).wait();
 
     // Generate initcode
     const simpleAccountFactoryAddress = process.env.SIMPLE_ACCOUNT_FACTORY_ADDRESS as string;


### PR DESCRIPTION
The paymaster needs to deposit Ether into the entrypoint contract in order to sponsor user transactions. Previously this was done in the test script, but for the paymaster service to serve its purpose, I've moved this to before starting the paymaster server. The amount to be deposited can be set in the config file. The deposit script can also be run anytime if the operator wants to top up funds. 